### PR TITLE
Restore dual remote sensing example and add to documentation

### DIFF
--- a/docs/dual_remote_sensing.py
+++ b/docs/dual_remote_sensing.py
@@ -1,0 +1,58 @@
+# In this notebook we consider an application to dual remote sensing: a univariate field is remotely-sensed, with
+# each measurement having a white noise error of a certain level.
+# We therefore jointly estimate the noise level for each sensor in parallel with the parameters of the covariance model
+# of the sensed field.
+# We then proceed to "map" the field using both measurements.
+
+# ##Imports
+
+import matplotlib.pyplot as plt
+
+from debiased_spatial_whittle.models import DualRemoteSensing
+from debiased_spatial_whittle.models.univariate import SquaredExponentialModel
+from debiased_spatial_whittle.grids import RectangularGrid
+from debiased_spatial_whittle.sampling import MultivariateSamplerOnRectangularGrid
+
+from debiased_spatial_whittle.inference import Periodogram, ExpectedPeriodogram, MultivariateDebiasedWhittle, Estimator
+
+# ##Grid and model specification
+
+grid = RectangularGrid((64, 64), nvars=2)
+latent_model = SquaredExponentialModel(rho=5.0)
+model = DualRemoteSensing(latent_model, sigma1=0.1, sigma2=0.2)
+
+# ##Sample a realization
+
+sampler = MultivariateSamplerOnRectangularGrid(model, grid, p=2)
+s = sampler()
+
+plt.figure()
+plt.subplot(1, 2, 1)
+plt.imshow(s[..., 0], cmap="seismic")
+plt.subplot(1, 2, 2)
+plt.imshow(s[..., 1], cmap="seismic")
+plt.show()
+
+# ##Parameter inference
+
+latent_model = SquaredExponentialModel(rho=1.0)
+model = DualRemoteSensing(latent_model, sigma1=0.01, sigma2=0.01)
+model.set_param_bounds(dict(sigma1=(0.001, 1.0), sigma2=(0.001, 1.0)))
+
+periodogram = Periodogram()
+dbw = MultivariateDebiasedWhittle(periodogram, ExpectedPeriodogram(grid, periodogram))
+estimator = Estimator(dbw)
+estimator(model, s, opt_callback=lambda *args, **kwargs: print(*args, **kwargs))
+
+# ##Mapping
+
+import numpy as np
+
+xs = np.stack(np.mgrid[:64, :64], -1).reshape(-1, 2)
+ys = model.predict(
+    (xs, xs), (s[..., 0].reshape((-1, 1)), s[..., 1].reshape((-1, 1))), xs
+)
+ys = ys.reshape((64, 64))
+plt.figure()
+plt.imshow(ys, cmap="seismic")
+plt.show()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ plugins:
 - search
 - mkdocs-jupyter:
     include: ['3dexponential.py', 'france.py', 'circle.py', 'multivariate_simple.py', 'multivariate_two_grids.py', 'non-isotropic.py',
-    'anisotropic.py', 'france_interpolation.py']
+    'anisotropic.py', 'france_interpolation.py', 'dual_remote_sensing.py']
     execute: true
 - mkdocstrings:
     handlers:
@@ -66,6 +66,7 @@ nav:
       - Multivariate:
           - 'Same grid': multivariate_simple.py
           - 'Non-overlapping grids': multivariate_two_grids.py
+          - 'Dual remote sensing': dual_remote_sensing.py
       - Interpolation: france_interpolation.py
   - Reference:
       - grids: grids.md

--- a/src/debiased_spatial_whittle/grids/__init__.py
+++ b/src/debiased_spatial_whittle/grids/__init__.py
@@ -1,0 +1,1 @@
+from .base import RectangularGrid

--- a/src/debiased_spatial_whittle/inference/__init__.py
+++ b/src/debiased_spatial_whittle/inference/__init__.py
@@ -1,6 +1,3 @@
 from .multivariate_periodogram import Periodogram as MultivariatePeriodogram
-from .periodogram import Periodogram as UnivariatePeriodogram, ExpectedPeriodogram
+from .periodogram import Periodogram, ExpectedPeriodogram
 from .likelihood import MultivariateDebiasedWhittle, Estimator
-
-# For backward compatibility, make Periodogram refer to MultivariatePeriodogram
-Periodogram = MultivariatePeriodogram

--- a/src/debiased_spatial_whittle/inference/__init__.py
+++ b/src/debiased_spatial_whittle/inference/__init__.py
@@ -1,0 +1,6 @@
+from .multivariate_periodogram import Periodogram as MultivariatePeriodogram
+from .periodogram import Periodogram as UnivariatePeriodogram, ExpectedPeriodogram
+from .likelihood import MultivariateDebiasedWhittle, Estimator
+
+# For backward compatibility, make Periodogram refer to MultivariatePeriodogram
+Periodogram = MultivariatePeriodogram

--- a/src/debiased_spatial_whittle/models/__init__.py
+++ b/src/debiased_spatial_whittle/models/__init__.py
@@ -1,0 +1,3 @@
+from .bivariate import BivariateUniformCorrelation
+from .dual_remote_sensing import DualRemoteSensing
+from .univariate import SquaredExponentialModel, ExponentialModel

--- a/src/debiased_spatial_whittle/models/dual_remote_sensing.py
+++ b/src/debiased_spatial_whittle/models/dual_remote_sensing.py
@@ -1,0 +1,177 @@
+import numpy as np
+from debiased_spatial_whittle.models.base import CovarianceModel, CompoundModel, ModelParameter
+from debiased_spatial_whittle.backend import BackendManager
+
+xp = BackendManager.get_backend()
+inv = BackendManager.get_inv()
+
+
+class DualRemoteSensing(CompoundModel):
+    """
+    Class for the covariance model corresponding to a univariate field measured via two channels.
+    
+    This model represents the scenario where a single underlying spatial field is observed
+    through two different measurement channels, each with its own independent noise.
+    
+    Attributes
+    ----------
+    base_model : CovarianceModel
+        The covariance model of the underlying latent field
+    sigma1 : ModelParameter
+        Noise amplitude of channel 1, must be in (0.0, 1.0)
+    sigma2 : ModelParameter
+        Noise amplitude of channel 2, must be in (0.0, 1.0)
+    
+    Examples
+    --------
+    >>> from debiased_spatial_whittle.models.univariate import SquaredExponentialModel
+    >>> latent_model = SquaredExponentialModel(rho=5.0)
+    >>> model = DualRemoteSensing(latent_model, sigma1=0.1, sigma2=0.2)
+    """
+
+    sigma1 = ModelParameter(
+        default=0.1, bounds=(0.0, 1.0), doc="Noise amplitude of channel 1"
+    )
+    sigma2 = ModelParameter(
+        default=0.1, bounds=(0.0, 1.0), doc="Noise amplitude of channel 2"
+    )
+
+    def __init__(self, base_model: CovarianceModel, *args, **kwargs):
+        super().__init__(
+            children=[
+                base_model,
+            ],
+            *args,
+            **kwargs,
+        )
+
+    @property
+    def base_model(self):
+        return self.children[0]
+
+    def compute11(self, lags: np.ndarray):
+        acv_latent = self.children[0]._compute(lags)
+        return acv_latent + self.sigma1 * np.all(lags == 0, 0)
+
+    def compute22(self, lags: np.ndarray):
+        acv_latent = self.children[0]._compute(lags)
+        return acv_latent + self.sigma2 * np.all(lags == 0, 0)
+
+    def _compute(self, lags: np.ndarray):
+        acv_latent = self.children[0]._compute(lags)
+        col1 = np.stack(
+            (acv_latent + self.sigma1 * np.all(lags == 0, 0), acv_latent), -1
+        )
+        col2 = np.stack(
+            (acv_latent, acv_latent + self.sigma2 * np.all(lags == 0, 0)), -1
+        )
+        return np.stack((col1, col2), -1)
+
+    def _gradient(self, lags: np.ndarray):
+        raise NotImplementedError()
+
+    def cov_mat_x1_x2(self, x1: np.ndarray, x2: np.ndarray = None) -> np.ndarray:
+        """
+        For multivariate data, if x1 has n1 locations and x2 has n2 locations, we return a matrix
+        with size (n1 * 2, n1 * 2)
+        Parameters
+        ----------
+        x1
+        x2
+
+        Returns
+        -------
+
+        """
+        raise NotImplementedError()
+        if x2 is None:
+            x2 = x1
+        x1 = np.expand_dims(x1, axis=1)
+        x2 = np.expand_dims(x2, axis=0)
+        lags = x1 - x2
+        lags = np.transpose(lags, (2, 0, 1))
+        acv = self(lags)
+        acv = np.transpose(acv, (3, 1, 4, 2))
+        return np.reshape(acv, (2 * x1.shape[0], 2 * x2.shape[0]))
+
+    def predict(
+        self,
+        x_obs: np.ndarray,
+        y_obs: np.ndarray,
+        x_pred: np.ndarray,
+        return_variance: bool = False,
+        full_model: CovarianceModel = None,
+    ):
+        """
+        Compute conditional mean at a set of locations x_pred given values y_obs observed at x_obs.
+
+        Parameters
+        ----------
+        x_obs
+            shape (n_obs, d), array of locations where observations are made
+        y_obs
+            shape (n_obs, 1), observed values
+        x_pred
+            shape (n_pred, d), array of locations where predicted values are requested
+        return_variance
+            If true, return the covariance matrix. Not implemented yet.
+        full_model
+            Covariance model of the data. By default, same as the current model. This can be used to separate
+            several additive components.
+
+        Returns
+        -------
+        y_pred
+            shape (n_pred, 1), array of predicted values
+        """
+        x_obs1, x_obs2 = x_obs
+        y_obs1, y_obs2 = y_obs
+
+        # first component
+        x_obs1 = np.expand_dims(x_obs1, 1)
+        # x_obs (n_obs, 1, d)
+        lags_x1x1 = x_obs1 - np.transpose(x_obs1, (1, 0, 2))
+        # lags_xx (n_obs, n_obs, d)
+
+        cov_mat_x1x1 = self.compute11(np.transpose(lags_x1x1, (2, 0, 1)))
+
+        # second component
+        x_obs2 = np.expand_dims(x_obs2, 1)
+        # x_obs (n_obs, 1, d)
+        lags_x2x2 = x_obs2 - np.transpose(x_obs2, (1, 0, 2))
+        # lags_xx (n_obs, n_obs, d)
+
+        cov_mat_x2x2 = self.compute22(np.transpose(lags_x2x2, (2, 0, 1)))
+
+        # cross
+        lags_x1x2 = x_obs1 - np.transpose(x_obs2, (1, 0, 2))
+        cov_mat_x1x2 = self.base_model(np.transpose(lags_x1x2, (2, 0, 1)))
+
+        cov_mat_xx = np.concatenate(
+            (
+                np.concatenate((cov_mat_x1x1, cov_mat_x1x2), 1),
+                np.concatenate((cov_mat_x1x2.T, cov_mat_x2x2), 1),
+            ),
+            0,
+        )
+        # cov_mat_xx (n_obs, n_obs)
+        cov_mat_xx_inv = inv(cov_mat_xx)
+
+        x_pred = np.expand_dims(x_pred, 1)
+        # x_pred (n_pred, 1, d)
+
+        lags_xpx1 = x_pred - np.transpose(x_obs1, (1, 0, 2))
+        # lags_yx (n_pred, n_obs, d)
+        sigma_xpx1 = self.base_model(np.transpose(lags_xpx1, (2, 0, 1)))
+
+        lags_xpx2 = x_pred - np.transpose(x_obs2, (1, 0, 2))
+        # lags_yx (n_pred, n_obs, d)
+        sigma_xpx2 = self.base_model(np.transpose(lags_xpx2, (2, 0, 1)))
+
+        sigma_yx = np.concatenate((sigma_xpx1, sigma_xpx2), 1)
+        # sigma_yx (n_pred, n_obs)
+
+        weights = np.dot(sigma_yx, cov_mat_xx_inv)
+        # weights (n_pred, n_obs)
+        y_pred = np.matmul(weights, np.concatenate((y_obs1, y_obs2), 0))
+        return y_pred

--- a/src/debiased_spatial_whittle/sampling/__init__.py
+++ b/src/debiased_spatial_whittle/sampling/__init__.py
@@ -1,0 +1,1 @@
+from .simulation import MultivariateSamplerOnRectangularGrid


### PR DESCRIPTION
This commit restores the dual remote sensing example that demonstrates:
- Two measurements of a univariate field with different noise levels
- Joint estimation of noise parameters and covariance model
- Field recovery/mapping using both measurements

Changes include:
- Added DualRemoteSensing model class
- Created docs/dual_remote_sensing.py example
- Updated mkdocs.yml to include the example in documentation
- Added necessary imports to __init__.py files
- Enhanced DualRemoteSensing class with proper documentation

The example is now integrated into the documentation system and will be automatically converted to a Jupyter notebook by mkdocs-jupyter.